### PR TITLE
Set info.png dimensions to 100% in 4k theme to address misalignment

### DIFF
--- a/config/theme-window-4k.txt
+++ b/config/theme-window-4k.txt
@@ -34,6 +34,8 @@ terminal-border: "0"
 + image {
   top = 0%
   left = 0%
+  height = 100%
+  width = 100%
   file = "info.png"
 }
 


### PR DESCRIPTION
Added height and width properties to the image component at 100% to stretch window.png (info.png), otherwise it's misaligned at 3840x2160